### PR TITLE
Run under Ubuntu 20.04

### DIFF
--- a/20-battery_swap_fix.rules
+++ b/20-battery_swap_fix.rules
@@ -1,3 +1,3 @@
 
-SUBSYSTEM=="power_supply",ENV{POWER_SUPPLY_ONLINE}=="0",RUN+="/usr/local/bin/battery_swap_fix.sh 1"
-SUBSYSTEM=="power_supply",ENV{POWER_SUPPLY_ONLINE}=="1",RUN+="/usr/local/bin/battery_swap_fix.sh 0"
+ACTION=="change",SUBSYSTEM=="power_supply",ENV{POWER_SUPPLY_ONLINE}=="0",RUN+="/usr/local/bin/battery_swap_fix.sh 1"
+ACTION=="change",SUBSYSTEM=="power_supply",ENV{POWER_SUPPLY_ONLINE}=="1",RUN+="/usr/local/bin/battery_swap_fix.sh 0"


### PR DESCRIPTION
Under Ubuntu 20.04 udev rule was not triggered until "change" ACTION was added.

```
ACTION=="change",SUBSYSTEM=="power_supply",RUN+=...
```